### PR TITLE
feat: enable conventional-commits

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,16 @@
   "command": {
     "init": {
       "exact": true
+    },
+    "create": {
+      "homepage": "https://github.com/Stinkstudios/npm-packages",
+      "license": "MIT"
+    },
+    "publish": {
+      "allowBranch": "master",
+      "conventionalCommits": true,
+      "gitRemote": "origin",
+      "message": "chore(release): publish"
     }
   },
   "packages": ["packages/*"],

--- a/package.json
+++ b/package.json
@@ -11,6 +11,19 @@
     "packages/*"
   ],
   "devDependencies": {
+    "@commitlint/cli": "7.2.1",
+    "@commitlint/config-conventional": "7.1.2",
+    "husky": "1.1.2",
     "lerna": "3.4.3"
+  },
+  "commitlint": {
+    "extends": [
+      "@commitlint/config-conventional"
+    ]
+  },
+  "husky": {
+    "hooks":{
+      "commitmsg": "commitlint -E GIT_PARAMS"
+    }
   }
 }


### PR DESCRIPTION
Using https://www.conventionalcommits.org to generate a changelog automatically when `lerna publish`